### PR TITLE
fix: harden Downloader against silent failures — add timeout, retry on OSError/Timeout, stream via iter_content

### DIFF
--- a/pyreposync/downloader.py
+++ b/pyreposync/downloader.py
@@ -117,6 +117,14 @@ class Downloader(object):
                 time.sleep(10)
             except OSRepoSyncDownLoadError:
                 break
+            except OSError as err:
+                self.log.error(f"could not write to destination, retry in 10 seconds: {err}")
+                retries -= 1
+                time.sleep(10)
+            except requests.exceptions.Timeout as err:
+                self.log.error(f"request timed out, retry in 10 seconds: {err}")
+                retries -= 1
+                time.sleep(10)
         self.log.error(f"{url} could not download")
         raise OSRepoSyncDownLoadError(f"{url} could not download")
 
@@ -144,12 +152,13 @@ class Downloader(object):
             proxies=self.proxy,
             cert=self.cert,
             verify=self.ca_cert,
+            timeout=(30, 300),
         )
         if r.status_code == 200:
             with open(destination, "wb", 0) as dst:
-                r.raw.decode_content = True
-                shutil.copyfileobj(r.raw, dst)
-                dst.flush()
+                for chunk in r.iter_content(chunk_size=65536):
+                    if chunk:
+                        dst.write(chunk)
         else:
             if not_found_ok:
                 if r.status_code == 404:


### PR DESCRIPTION
### Problem

Three independent failure modes in `Downloader` can cause `sync_packages()` to skip packages silently — without raising an exception, without logging an error, and without setting pyreposync's exit code to non-zero. The result is that `snap` proceeds on an incomplete sync, creating dangling symlinks for packages that were never downloaded. The symptom on the client side is HTTP 403 responses from the repository web server (nginx returns 403 for broken symlinks by default).

---

**Failure 1 — `OSError` from `shutil.move()` escapes all handlers**

When `shutil.move(tmp_file, destination)` raises `OSError` (for example, a stale file handle or an I/O error on a network-mounted destination), the `except OSError: raise` inside the `TemporaryDirectory` context re-raises it. The retry `while` loop catches only `requests.exceptions.ConnectionError`, `OSRepoSyncHashError`, and `OSRepoSyncDownLoadError` — `OSError` falls through all of them, propagates out of `get()` and through `sync_packages()`, and reaches `do_sync()`. `do_sync()` catches `OSRepoSyncException` but **not** `OSError`. The `RepoSyncThread` dies with `self.status` never set to 1. `pyreposync` exits 0. `snap` runs and creates dangling symlinks for every package that was not yet downloaded at the time of failure.

**Failure 2 — No timeout on `requests.get()`**

Without a timeout, a stalled HTTP connection hangs indefinitely. The thread never progresses, no error is logged, and on systems with an outer job timeout the run is eventually killed with no actionable diagnostic.

**Failure 3 — `urllib3.exceptions.ProtocolError` (IncompleteRead) escapes all handlers**

When the server drops the TCP connection mid-body — for example, a CDN node resetting after transmitting a partial response — `shutil.copyfileobj(r.raw, dst)` raises `urllib3.exceptions.ProtocolError` wrapping `IncompleteRead`. Because `r.raw` is accessed directly (bypassing requests' exception-wrapping layer), the exception is **not** a `requests.exceptions.ConnectionError`. It escapes the retry loop entirely and follows the same silent-exit-0 path as Failure 1.

In observed production usage all three failures manifested on large repositories with thousands of packages. Failures 1 and 3 together caused hundreds of packages to be absent from a snapshot with no log evidence of failure. The nightly sync re-ran the following day and completed successfully, confirming the failures were transient in nature.

---

### Fix

**1. Add a request timeout**

```python
r = requests.get(
    url,
    ...
    timeout=(30, 300),   # 30 s connect timeout, 300 s read timeout
)
```

300 s for the read timeout is generous enough for large packages on constrained links while still bounding runaway connections.

**2. Add `OSError` and `Timeout` to the retry loop — as separate handlers**

```python
except OSError as err:
    self.log.error(f"could not write to destination, retry in 10 seconds: {err}")
    retries -= 1
    time.sleep(10)
except requests.exceptions.Timeout as err:
    self.log.error(f"request timed out, retry in 10 seconds: {err}")
    retries -= 1
    time.sleep(10)
```

These join the existing `ConnectionError` and `OSRepoSyncHashError` retry paths. After all retries are exhausted the existing `raise OSRepoSyncDownLoadError(...)` fires, propagates through `sync_packages()`, sets the thread status to 1, and causes pyreposync to exit non-zero — which prevents `snap` from running on an incomplete sync.

**3. Replace `shutil.copyfileobj(r.raw, dst)` with `r.iter_content()`**

```python
with open(destination, "wb", 0) as dst:
    for chunk in r.iter_content(chunk_size=65536):
        if chunk:
            dst.write(chunk)
```

`iter_content()` is requests' documented streaming API. Unlike direct `r.raw` access it wraps urllib3 exceptions (`ProtocolError`, `IncompleteRead`) as `requests.exceptions.ChunkedEncodingError` — a subclass of `ConnectionError` — which is already caught and retried by the existing handler. The `if chunk:` guard discards empty byte objects that can appear from HTTP chunked-encoding keep-alive frames or at decompression block boundaries.

`r.raw.decode_content = True` is removed because `iter_content()` passes `decode_content=True` to urllib3's `stream()` internally. `dst.flush()` is removed because the file is opened with `buffering=0` (unbuffered), making an explicit flush a no-op.

---

### Effect

After this fix:

- Transient filesystem or NFS write errors are retried up to 10 times before failing
- Stalled HTTP connections time out after 300 s and are retried
- Connections dropped during body streaming are retried via the existing `ConnectionError` handler
- Any failure that exhausts all retries raises `OSRepoSyncDownLoadError`, causes pyreposync to exit non-zero, and prevents `snap` from creating dangling symlinks for undownloaded packages

The public interface is unchanged: `sync_packages()` and all callers require no modification.

---

*This change and write-up were prepared with the assistance of Claude Sonnet 4.6 (model ID: claude-sonnet-4-6) by Anthropic.*